### PR TITLE
move versioning to the code and handle unversioned S3 Buckets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,15 @@ def long_description():
     with open('README.md', 'r') as file:
         return file.read()
 
+def get_version():
+    from sqlite_s3_query import version
+    return version
+
+version = get_version()
 
 setuptools.setup(
     name='sqlite-s3-query',
-    version='0.0.34',
+    version=version,
     author='Michal Charemza',
     author_email='michal@charemza.name',
     description='Python context manager to query a SQLite file stored on S3',

--- a/sqlite_s3_query.py
+++ b/sqlite_s3_query.py
@@ -151,6 +151,8 @@ def sqlite_s3_query(url, get_credentials=lambda: (
             head_headers = response.headers
             next(response.iter_bytes())
         logger.debug(f"{head_headers}")
+
+        # this tag can be missing when working with unversioned S3 buckets
         version_id = head_headers.get('x-amz-version-id') 
         size = int(head_headers['content-length'])
 


### PR DESCRIPTION
This PR fixes a problm when accessing data stored in an unversioned S3 bucket.

There is one other change. moving the version info into the code.  (I can retract that part if it is not wanted)

This url demonstrates the problem
https://fema-cap-imagery.s3.us-east-1.amazonaws.com/Support/cap_index.gpkg


A sample query might be
    with sqlite_s3_query.sqlite_s3_query("https://fema-cap-imagery.s3.us-east-1.amazonaws.com/Support/cap_index.gpkg") as query:
        with query("""SELECT fid, Id, ImageEventName  FROM images LIMIT 4 OFFSET 1000""") as (cols, rows):
            ......

