### PR TITLE
feat: 1 fewer requests: avoid checking change counter or sizes

### DIFF
--- a/sqlite_s3_query.py
+++ b/sqlite_s3_query.py
@@ -38,6 +38,7 @@ def sqlite_s3_query_multi(url, get_credentials=lambda now: (
     SQLITE_TRANSIENT = -1
     SQLITE_OPEN_READONLY = 0x00000001
     SQLITE_OPEN_URI = 0x00000040
+    SQLITE_IOCAP_IMMUTABLE = 0x00002000
 
     bind = {
         type(0): libsqlite3.sqlite3_bind_int64,
@@ -207,7 +208,7 @@ def sqlite_s3_query_multi(url, get_credentials=lambda now: (
 
         x_device_characteristics_type = CFUNCTYPE(c_int, c_void_p)
         def x_device_characteristics(p_file):
-            return 0
+            return SQLITE_IOCAP_IMMUTABLE
 
         x_access_type = CFUNCTYPE(c_int, c_void_p, c_char_p, c_int, POINTER(c_int))
         def x_access(p_vfs, z_name, flags, z_out):

--- a/test.py
+++ b/test.py
@@ -437,17 +437,26 @@ class TestSqliteS3Query(unittest.TestCase):
                 for row in rows:
                     rows_count += 1
 
-        self.assertEqual(rows_yielded_at_request, [
+        self.assertIn(rows_yielded_at_request, ([
             (0, None),
             (0, 'bytes=0-99'),
             (0, 'bytes=0-4095'),
-            (0, 'bytes=24-39'),
+            (0, 'bytes=24-39'),  # For older SQLite that doesn't support immutable files
             (0, 'bytes=4096-8191'),
             (0, 'bytes=8192-12287'),
             (140, 'bytes=12288-16383'),
             (276, 'bytes=16384-20479'),
             (412, 'bytes=20480-24575'),
-        ])
+        ], [
+            (0, None),
+            (0, 'bytes=0-99'),
+            (0, 'bytes=0-4095'),
+            (0, 'bytes=4096-8191'),
+            (0, 'bytes=8192-12287'),
+            (140, 'bytes=12288-16383'),
+            (276, 'bytes=16384-20479'),
+            (412, 'bytes=20480-24575'),
+        ]))
 
         # Documenting the difference with the above and a query that is not streaming. In this
         # case, a query with an ORDER BY on a column that does not have an index requires SQLite to
@@ -464,17 +473,26 @@ class TestSqliteS3Query(unittest.TestCase):
                 for row in rows:
                     rows_count += 1
 
-        self.assertEqual(rows_yielded_at_request, [
+        self.assertIn(rows_yielded_at_request, ([
             (0, None),
             (0, 'bytes=0-99'),
             (0, 'bytes=0-4095'),
-            (0, 'bytes=24-39'),
+            (0, 'bytes=24-39'),  # For older SQLite that doesn't support immutable files
             (0, 'bytes=4096-8191'),
             (0, 'bytes=8192-12287'),
             (0, 'bytes=12288-16383'),
             (0, 'bytes=16384-20479'),
             (0, 'bytes=20480-24575'),
-        ])
+        ], [
+            (0, None),
+            (0, 'bytes=0-99'),
+            (0, 'bytes=0-4095'),
+            (0, 'bytes=4096-8191'),
+            (0, 'bytes=8192-12287'),
+            (0, 'bytes=12288-16383'),
+            (0, 'bytes=16384-20479'),
+            (0, 'bytes=20480-24575'),
+        ]))
 
     def test_too_many_bytes(self):
         @contextmanager


### PR DESCRIPTION
We can tell SQLite that the file is immutable since versioning in S3 is enforced