### PR TITLE
change  x_file_size to take an int64 pointer instead of an int pointer 

### DIFF
--- a/sqlite_s3_query.py
+++ b/sqlite_s3_query.py
@@ -188,7 +188,7 @@ def sqlite_s3_query_multi(url, get_credentials=lambda now: (
 
             return SQLITE_OK
 
-        x_file_size_type = CFUNCTYPE(c_int, c_void_p, POINTER(c_int))
+        x_file_size_type = CFUNCTYPE(c_int, c_void_p, POINTER(c_int64))
         def x_file_size(p_file, p_size):
             p_size[0] = size
             return SQLITE_OK


### PR DESCRIPTION
I get a message of 'database image is malformed' on files > 4GB 

Changing:

        x_file_size_type = CFUNCTYPE(c_int, c_void_p, POINTER(c_int))
        def x_file_size(p_file, p_size):
            p_size[0] = size
            return SQLITE_OK

To accept a 64bit pointer 

        x_file_size_type = CFUNCTYPE(c_int, c_void_p, POINTER(c_int64))

fixes the issue