### PR TITLE
fix: work on httpx 0.23.0

### DIFF
--- a/sqlite_s3_query.py
+++ b/sqlite_s3_query.py
@@ -140,7 +140,7 @@ def sqlite_s3_query_multi(url, get_credentials=lambda now: (
     def get_vfs(http_client):
         with make_auth_request(http_client, 'HEAD', (), ()) as response:
             head_headers = response.headers
-            next(response.iter_bytes())
+            next(response.iter_bytes(), b'')
 
         try:
             version_id = head_headers['x-amz-version-id']


### PR DESCRIPTION
In previous versions of https, a HEAD request's iter_bytes would return a simple empty byte string. Now, it looks like no byte string it returned, and so `next` would raise a StopIteration. We use the 2nd argument to `next` to ignore the StopIteration if it happens.

(The `next` is there it exhaust the iterable to make sure httpx knows it can re-use the connection to S3)