### PR TITLE
ci: update to recent minio

### DIFF
--- a/start-services.sh
+++ b/start-services.sh
@@ -3,15 +3,12 @@
 set -e
 
 docker run --rm -p 9000:9000 --name sqlite-s3-query-minio -d \
-  -e 'MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE' \
-  -e 'MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY' \
+  -e 'MINIO_ROOT_USER=AKIAIOSFODNN7EXAMPLE' \
+  -e 'MINIO_ROOT_PASSWORD=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY' \
   -e 'MINIO_REGION=us-east-1' \
   --entrypoint sh \
-  minio/minio:RELEASE.2021-08-05T22-01-19Z \
+  minio/minio:RELEASE.2023-07-21T21-12-44Z \
   -c '
-    mkdir -p /data1 &&
-    mkdir -p /data2 &&
-    mkdir -p /data3 &&
-    mkdir -p /data4 &&
-    minio server /data{1...4}
+    mkdir -p /data
+    minio server /data
   '


### PR DESCRIPTION
I suspect that the multi-volume thing was required in the older version to allow for versioning. However, this is no longer the case, and in fact MinIO complains if the different folders are on the same volume. So it's easier for testing to just used the one.