### PR TITLE
ci: Windows compatibility of CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,21 +70,16 @@ jobs:
           - {os: "ubuntu-20.04", python: "3.10.0"}
           - {os: "ubuntu-20.04", python: "3.11.0"}
     runs-on: '${{ matrix.os-and-python-version.os }}'
+    env:
+      MINIO_ROOT_USER: AKIAIOSFODNN7EXAMPLE
+      MINIO_ROOT_PASSWORD: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+      MINIO_REGION: us-east-1
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v3"
       - uses: "actions/setup-python@v4"
         with:
           python-version: '${{ matrix.os-and-python-version.python }}'
-      - name: "Run MinIO"
-        run: |
-          wget -O minio https://dl.min.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2023-07-21T21-12-44Z
-          chmod +x minio
-          mkdir -p ./data
-          export MINIO_ROOT_USER=AKIAIOSFODNN7EXAMPLE
-          export MINIO_ROOT_PASSWORD=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-          export MINIO_REGION=us-east-1
-          ./minio server ${PWD}/data &
       - uses: actions/download-artifact@v3
         with:
           name: reporter
@@ -106,6 +101,11 @@ jobs:
           pip install ".[dev]"
       - name: "Test"
         run: |
+          wget -O minio https://dl.min.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2023-07-21T21-12-44Z
+          chmod +x minio
+          mkdir -p ./data
+          ./minio server ./data &
+          timeout 22 sh -c 'until nc -z $0 $1; do sleep 1; done' 127.0.0.1 9000
           coverage run -m unittest
           coverage xml
           chmod +x ./reporter/cc-test-reporter

--- a/test.py
+++ b/test.py
@@ -829,8 +829,9 @@ def aws_sigv4_headers(access_key_id, secret_access_key, pre_auth_headers,
 
 @contextmanager
 def get_db(sqls):
-    with tempfile.NamedTemporaryFile() as fp:
-        with sqlite3.connect(fp.name, isolation_level=None) as con:
+    with tempfile.TemporaryDirectory() as directory_name:
+        db_path = os.path.join(directory_name, 'sqlite-s3-query-test.db')
+        with sqlite3.connect(db_path, isolation_level=None) as con:
             cur = con.cursor()
             cur.execute('BEGIN')
             for sql, params in sqls:
@@ -838,7 +839,7 @@ def get_db(sqls):
             cur.execute('COMMIT')
 
         def db():
-            with open(fp.name, 'rb') as f:
+            with open(db_path, 'rb') as f:
                 while True:
                     chunk = f.read(65536)
                     if not chunk:


### PR DESCRIPTION
To run tests on Windows:

- Setting environment variables for the entire job was the only way I could work out how to set for processes running in the job

- MinIO seems to close after the step, even if run in the backround. So, running it in the same step as the tests is required

- NamedTemporaryFile opens the file, which on Windows forbids it from being opened by SQLite. So, avoiding this.