### PR TITLE
ci: wait for all tests before reporting coverage results

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,3 @@
 comment: false
+notify:
+  wait_for_ci: yes


### PR DESCRIPTION
This is to not report less coverage than there is