### PR TITLE
ci: test more recent HTTPX

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,12 @@ jobs:
           - "3.9.0"
           - "3.10.0"
           - "3.11.0"
+        package-extras:
+          - "ci-earliest"
+          - "ci-latest"
+        exclude:
+          - python-version: "3.6.7"
+            package-extras: "ci-latest"
     runs-on: '${{ matrix.os }}'
     env:
       SQLITE3_VERSION: ${{ matrix.sqlite-version }}
@@ -107,7 +113,7 @@ jobs:
           echo "LIBSQLITE3_PATH=${PWD}/libsqlite3.so.0" >> "$GITHUB_ENV"
       - name: "Install sqlite-s3-query and any dependencies"
         run: |
-          pip install ".[dev,ci]"
+          pip install ".[dev,${{ matrix.package-extras }}]"
       - name: "Test (Windows)"
         if: matrix.os == 'windows-2019'
         run: |

--- a/README.md
+++ b/README.md
@@ -228,4 +228,4 @@ It is safe for multiple threads to call the same `query` function. Under the hoo
 - Linux (tested on Ubuntu 20.04), Windows (tested on Windows Server 2019), or macOS (tested on macOS 11)
 - SQLite >= 3.7.15, (tested on 3.7.15, 3.36.0, 3.42.0, and the default version available on each OS tested)
 - Python >= 3.6.7 (tested on 3.6.7, 3.7.1, 3.8.0, 3.9.0, 3.10.0, and 3.11.0)
-- HTTPX >= 0.18.2 (tested on 0.18.2)
+- HTTPX >= 0.18.2 (tested on 0.18.2 with Python >= 3.6.7, and 0.24.1 with Python >= 3.7.1)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
 comment: false
 codecov:
   notify:
-    after_n_builds: 72
+    after_n_builds: 132

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,11 @@ dependencies = [
 dev = [
     "coverage",
 ]
-ci = [
+ci-earliest = [
     "httpx==0.18.2",
+]
+ci-latest = [
+    "httpx==0.24.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
HTTPX is < 1, and each change is allowed to be breaking according to SemVer (not that I'm sure if HTTPX is following it... but just in case).