### PR TITLE
docs: promote multithreading section

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,8 @@ with \
         print(row)
 ```
 
-### Multithreading
+
+## Multithreading
 
 It is safe for multiple threads to call the same `query` function. Under the hood, each use of `query` uses a separate SQLite "connection" to the database combined with the `SQLITE_OPEN_NOMUTEX` flag, which makes this safe while not locking unnecessarily.
 


### PR DESCRIPTION
I think now it's a bit odd it's in Usage - there are are top level "appendix-y" sections that it's more similar to.