### PR TITLE
feat: raise any httpx exceptions, e.g. from failed auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,13 @@ This means that sqlite-s3-query is not for all use cases of querying SQLite data
 This is not necessarily a permanent decision - it is possible that in future sqlite-s3-query will support unversioned buckets.
 
 
-## Exception hierarchy
+## Exceptions
+
+Under the hood [HTTPX](https://www.python-httpx.org/) is used to communicate with S3, but any [exceptions raised by HTTPX](https://www.python-httpx.org/exceptions/) are passed through to client code unchanged. This includes `httpx.HTTPStatusError` when S3 returns a non-200 response. Most commonly this will be when S3 returns a 403 in the case of insufficient permissions on the database object being queried.
+
+All other exceptions raised inherit from `sqlite_s3_query.SQLiteS3QueryError` as described in the following hierarchy.
+
+### Exception hierarchy
 
 - `SQLiteS3QueryError`
 


### PR DESCRIPTION
This means that 403s, such as those from not being allowed to fetch a specific version, are passed to client code, and so help debug permission errors better than the disk i/o error that's being raised right now.

It also means there is consistency - before this change if there's a 403 (or any other connection error) from the initial HEAD request on the start of a query, then that was being passed to client now. Now, during the read data during the query if these get raised they get passed to client code.

A few more tests have been added that seem maybe unreleated, but they test code paths of when there are not any httpx exception, but there are SQLite exceptions.