### PR TITLE
ci: test on more recent macOS (since older is no longer available)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
         # If changing how many times tests are run, must also change in codecov.yml
         # to ensure test coverage is reported only after all tests have finished
         os:
-          - "macos-11"
+          - "macos-12"
           - "ubuntu-20.04"
           - "windows-2019"
         sqlite-version:
@@ -107,7 +107,7 @@ jobs:
           gcc -shared sqlite3.c -o sqlite3.dll
           echo "LIBSQLITE3_PATH=${PWD}/sqlite3.dll" >> $env:GITHUB_ENV
       - name: "Compile SQLite from amalgamation (Ubuntu or macOS)"
-        if: (matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-11') && matrix.sqlite-version != 'default'
+        if: (matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-12') && matrix.sqlite-version != 'default'
         run: |
           gcc -shared -fPIC -o libsqlite3.so.0 sqlite3.c
           echo "LIBSQLITE3_PATH=${PWD}/libsqlite3.so.0" >> "$GITHUB_ENV"
@@ -133,11 +133,11 @@ jobs:
           until nc -w 10 127.0.0.1 9000; do sleep 1; done
           coverage run -m unittest
       - name: "Test (macOS)"
-        if: matrix.os == 'macos-11'
+        if: matrix.os == 'macos-12'
         run: |
           mkdir -p ./data
           chmod +x ./minio/minio-darwin
           ./minio/minio-darwin server ./data &
           until nc -w 10 127.0.0.1 9000; do sleep 1; done
           coverage run -m unittest
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ All other exceptions raised inherit from `sqlite_s3_query.SQLiteS3QueryError` as
 
 ## Compatibility
 
-- Linux (tested on Ubuntu 20.04), Windows (tested on Windows Server 2019), or macOS (tested on macOS 11)
+- Linux (tested on Ubuntu 20.04), Windows (tested on Windows Server 2019), or macOS (tested on macOS 12)
 - SQLite >= 3.7.15, (tested on 3.7.15, 3.36.0, 3.42.0, and the default version available on each OS tested)
 - Python >= 3.6.7 (tested on 3.6.7, 3.7.1, 3.8.0, 3.9.0, 3.10.0, and 3.11.0)
 - HTTPX >= 0.18.2 (tested on 0.18.2 with Python >= 3.6.7, and 0.24.1 with Python >= 3.7.1)


### PR DESCRIPTION
This seemed to need a bump of the codecov upload action due to the error

> Error: spawn Unknown system error -86